### PR TITLE
fix: pass Slack release secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,5 @@ jobs:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}
       supermarket_key: ${{ secrets.CHEF_SUPERMARKET_KEY }}
+      slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+      slack_channel_id: ${{ secrets.SLACK_CHANNEL_ID }}


### PR DESCRIPTION
## Summary
- pass the required Slack secrets to the reusable release workflow
- base the branch on current main, which already includes the docker-engine custom resource migration
- preserve the existing CI pin to install-workstation@6.0.0 and avoid chef/chefworkstation in Kitchen

## Testing
- git diff --check
- yq '.jobs.release.secrets' .github/workflows/release.yml